### PR TITLE
Add reactive API status indicator

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,8 @@ createApp({
     } = useDictionary();
 
     const {
-      apiUrl, apiKey, apiError, inputSentence, jsonLevel1TreeLoading, jsonTree, resultSentence,
+      apiUrl, apiKey, apiError, apiStatusState, apiStatusMessage, setApiStatus,
+      inputSentence, jsonLevel1TreeLoading, jsonTree, resultSentence,
       jsonButtonState, jsonLevel2TreeLoading, jsonLevel3TreeLoading,
       inputLoadingDuration, jsonLoadingDuration,
       jsonButtonTitle,
@@ -31,7 +32,8 @@ createApp({
       // 字典相关
       dictRows, searchText, dictLoaded, dictError, sortedRows, filteredRows, loadDefaultDictionary, highlight,
       // LLM相关
-      apiUrl, apiKey, apiError, inputSentence, jsonLevel1TreeLoading, jsonTree, resultSentence,
+      apiUrl, apiKey, apiError, apiStatusState, apiStatusMessage, setApiStatus,
+      inputSentence, jsonLevel1TreeLoading, jsonTree, resultSentence,
       jsonButtonState, jsonLevel2TreeLoading, jsonLevel3TreeLoading,
       inputLoadingDuration, jsonLoadingDuration,
       jsonButtonTitle,

--- a/index.html
+++ b/index.html
@@ -115,10 +115,36 @@
             <div class="flex items-center gap-2">
               <span class="text-sm text-gray-500">API 状态</span>
               <span
-                class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700"
-                title="占位状态"
+                v-if="apiStatusState === 'loading'"
+                class="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700"
+                :title="apiStatusMessage"
               >
-                未连接
+                <svg class="mr-1 h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4A4 4 0 008 12H4z"></path>
+                </svg>
+                {{ apiStatusMessage }}
+              </span>
+              <span
+                v-else-if="apiStatusState === 'error'"
+                class="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-700"
+                :title="apiStatusMessage"
+              >
+                {{ apiStatusMessage || '请求失败' }}
+              </span>
+              <span
+                v-else-if="apiStatusState === 'success'"
+                class="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700"
+                :title="apiStatusMessage"
+              >
+                {{ apiStatusMessage || '已连接' }}
+              </span>
+              <span
+                v-else
+                class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700"
+                :title="apiStatusMessage"
+              >
+                {{ apiStatusMessage || '未连接' }}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a dynamic API status chip in the header with loading, success, and error visuals
- expose reactive API status state/message and setter from the LLM composable
- update parsing routines to drive the API status updates based on request progress

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e89106808328be786139e7144193