### PR TITLE
Add Next.js component scaffolding

### DIFF
--- a/next-app/README.md
+++ b/next-app/README.md
@@ -1,0 +1,21 @@
+# Next.js 迁移草稿
+
+本目录包含一个将原始 `index.html` 页面拆分后的组件化结构，方便迁移到使用 **Next.js + TypeScript** 的新仓库。文件遵循 App Router 约定，可直接复制到 Next.js 项目的根目录下，并根据需要调整依赖。
+
+## 目录结构
+
+- `app/page.tsx`：页面入口，组合各个功能区域。
+- `app/api/*`：示例 API Route，占位符逻辑可替换为真实实现。
+- `components/`：按功能区拆分的 React 组件。
+- `hooks/`：与占位符逻辑相关的 React Hooks。
+- `lib/placeholders/`：示例数据与工具函数。
+- `types/`：共享的 TypeScript 类型定义。
+
+## 后续接入建议
+
+1. **真实数据源**：替换 `lib/placeholders` 与 `hooks` 中的假数据逻辑，改为调用实际的 API 或数据库。
+2. **状态管理**：根据需求选择使用 React Context、Redux、Zustand 等工具管理全局状态。
+3. **样式与 UI**：当前沿用了 Tailwind CSS class 名称，在 Next.js 中可继续使用 `tailwind.config.js` 进行配置。
+4. **API 安全**：在 `app/api` 路由中实现鉴权、错误处理与日志上报。
+
+将该目录复制到新的 Next.js 仓库后，安装必要依赖并补充实际业务逻辑即可开始开发与部署。

--- a/next-app/app/api/dictionary/route.ts
+++ b/next-app/app/api/dictionary/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getSampleDictionaryEntries } from "../../../lib/placeholders/dictionaryClient";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "placeholder",
+    message: "返回示例字典数据，待替换为真实逻辑。",
+    data: getSampleDictionaryEntries(),
+  });
+}

--- a/next-app/app/api/parse/route.ts
+++ b/next-app/app/api/parse/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({ input: "" }));
+  const input: string = body?.input ?? "";
+
+  return NextResponse.json({
+    status: "placeholder",
+    message: "解析逻辑尚未实现。",
+    input,
+    result: input ? `解析结果占位：${input}` : null,
+  });
+}

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -1,0 +1,22 @@
+import AppShell from "../components/Layout/AppShell";
+import PageHeader from "../components/Header/PageHeader";
+import DictionaryPanel from "../components/Dictionary/DictionaryPanel";
+import ParserPanel from "../components/Parser/ParserPanel";
+import StructureTreePanel from "../components/StructureTree/StructureTreePanel";
+
+export default function HomePage() {
+  return (
+    <AppShell>
+      <PageHeader />
+      <main className="flex-1">
+        <div className="mx-auto max-w-[1400px] px-4 py-4">
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_2fr_1.5fr]">
+            <DictionaryPanel />
+            <ParserPanel />
+            <StructureTreePanel />
+          </div>
+        </div>
+      </main>
+    </AppShell>
+  );
+}

--- a/next-app/components/Dictionary/DictionaryPanel.tsx
+++ b/next-app/components/Dictionary/DictionaryPanel.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useDictionarySearch } from "../../hooks/useDictionarySearch";
+import { HighlightedText } from "../../lib/placeholders/highlight";
+
+export function DictionaryPanel() {
+  const { searchText, setSearchText, filteredRows } = useDictionarySearch();
+
+  return (
+    <section className="flex min-h-[60vh] flex-col rounded-2xl border bg-white p-4" data-testid="dictionary-panel">
+      <div className="mb-3">
+        <h2 className="text-base font-semibold">查询字典</h2>
+        <p className="mt-0.5 text-xs text-gray-500">这里展示字典查询结果（占位）。</p>
+      </div>
+
+      <div className="mb-3 flex gap-2">
+        <input
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+          type="text"
+          placeholder="输入要查询的词…"
+          className="w-full rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div className="max-h-96 overflow-auto rounded-md border">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr className="text-left">
+              <th className="px-3 py-2 font-semibold">道本语</th>
+              <th className="px-3 py-2 font-semibold">翻译</th>
+              <th className="px-3 py-2 font-semibold">释义</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredRows.map((row, index) => (
+              <tr key={`${row.source}-${index}`} className="border-t">
+                <td className="px-3 py-2">
+                  <HighlightedText text={row.source} query={searchText} />
+                </td>
+                <td className="px-3 py-2">
+                  <HighlightedText text={row.translation} query={searchText} />
+                </td>
+                <td className="px-3 py-2">
+                  <HighlightedText text={row.description} query={searchText} />
+                </td>
+              </tr>
+            ))}
+
+            {filteredRows.length === 0 && (
+              <tr>
+                <td className="px-3 py-8 text-center text-gray-500" colSpan={3}>
+                  未找到匹配项
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default DictionaryPanel;

--- a/next-app/components/Header/ApiConfigForm.tsx
+++ b/next-app/components/Header/ApiConfigForm.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+
+export function ApiConfigForm() {
+  const [apiUrl, setApiUrl] = useState("https://api.example.com/parse");
+  const [apiKey, setApiKey] = useState("");
+
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-3" data-testid="api-config-form">
+      <div className="col-span-1 sm:col-span-2">
+        <label className="mb-1 block text-xs text-gray-500" htmlFor="api-endpoint">
+          API Endpoint
+        </label>
+        <input
+          id="api-endpoint"
+          value={apiUrl}
+          onChange={(event) => setApiUrl(event.target.value)}
+          type="text"
+          placeholder="https://api.example.com/parse"
+          className="w-full rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+      <div className="col-span-1">
+        <label className="mb-1 block text-xs text-gray-500" htmlFor="api-key">
+          API Key
+        </label>
+        <input
+          id="api-key"
+          value={apiKey}
+          onChange={(event) => setApiKey(event.target.value)}
+          type="password"
+          placeholder="••••••••"
+          className="w-full rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default ApiConfigForm;

--- a/next-app/components/Header/DictionaryControls.tsx
+++ b/next-app/components/Header/DictionaryControls.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PlaceholderButton } from "../placeholders/PlaceholderButton";
+
+export function DictionaryControls() {
+  return (
+    <div className="flex flex-wrap items-center gap-2" data-testid="dictionary-controls">
+      <span className="text-sm font-semibold text-gray-700">字典管理</span>
+      <PlaceholderButton label="上传字典" tooltip="上传/导入字典" />
+      <PlaceholderButton label="切换字典" tooltip="切换字典" />
+      <PlaceholderButton
+        label="刷新状态"
+        tooltip="刷新状态"
+        onClickPlaceholder={() => {
+          console.info("loadDefaultDictionary placeholder invoked");
+        }}
+      />
+    </div>
+  );
+}
+
+export default DictionaryControls;

--- a/next-app/components/Header/PageHeader.tsx
+++ b/next-app/components/Header/PageHeader.tsx
@@ -1,0 +1,19 @@
+import ApiConfigForm from "./ApiConfigForm";
+import DictionaryControls from "./DictionaryControls";
+import StatusBar from "./StatusBar";
+
+export function PageHeader() {
+  return (
+    <header className="border-b bg-white" data-testid="page-header">
+      <div className="mx-auto max-w-[1400px] space-y-3 px-4 py-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <DictionaryControls />
+          <ApiConfigForm />
+        </div>
+        <StatusBar />
+      </div>
+    </header>
+  );
+}
+
+export default PageHeader;

--- a/next-app/components/Header/StatusBar.tsx
+++ b/next-app/components/Header/StatusBar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useApiStatusPlaceholder, useDictionaryStatusPlaceholder } from "../../hooks/useStatusPlaceholders";
+import type { ApiStatus, DictionaryStatus, StatusState } from "../../types/status";
+
+function renderDictionaryBadge({ state, totalEntries, errorMessage }: DictionaryStatus) {
+  switch (state) {
+    case "loading":
+      return (
+        <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700" title="正在加载 dictionary.csv">
+          <svg className="mr-1 h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4A4 4 0 008 12H4z"></path>
+          </svg>
+          加载中…
+        </span>
+      );
+    case "error":
+      return (
+        <span className="inline-flex items-center rounded-full bg-red-50 px-3 py-1 text-xs font-medium text-red-700" title={errorMessage ?? "加载失败"}>
+          加载失败
+        </span>
+      );
+    case "success":
+      return (
+        <span className="inline-flex items-center rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700" title={`已成功加载 ${totalEntries ?? 0} 条`}>
+          已加载 {totalEntries ?? 0} 条
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700" title="占位状态">
+          未加载
+        </span>
+      );
+  }
+}
+
+function renderApiBadge(state: StatusState, message?: string) {
+  const baseClass = "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium";
+  switch (state) {
+    case "loading":
+      return (
+        <span className={`${baseClass} bg-blue-50 text-blue-700`} title={message}>
+          <svg className="mr-1 h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4A4 4 0 008 12H4z"></path>
+          </svg>
+          {message ?? "请求中"}
+        </span>
+      );
+    case "error":
+      return (
+        <span className={`${baseClass} bg-red-50 text-red-700`} title={message}>
+          {message ?? "请求失败"}
+        </span>
+      );
+    case "success":
+      return (
+        <span className={`${baseClass} bg-green-50 text-green-700`} title={message}>
+          {message ?? "已连接"}
+        </span>
+      );
+    default:
+      return (
+        <span className={`${baseClass} bg-gray-100 text-gray-700`} title={message}>
+          {message ?? "未连接"}
+        </span>
+      );
+  }
+}
+
+export function StatusBar() {
+  const dictionaryStatus: DictionaryStatus = useDictionaryStatusPlaceholder();
+  const apiStatus: ApiStatus = useApiStatusPlaceholder();
+
+  return (
+    <div className="flex flex-wrap items-center gap-3" data-testid="status-bar">
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-gray-500">字典状态</span>
+        {renderDictionaryBadge(dictionaryStatus)}
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-gray-500">API 状态</span>
+        {renderApiBadge(apiStatus.state, apiStatus.message)}
+      </div>
+    </div>
+  );
+}
+
+export default StatusBar;

--- a/next-app/components/Layout/AppShell.tsx
+++ b/next-app/components/Layout/AppShell.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from "react";
+
+export function AppShell({ children }: PropsWithChildren) {
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <div className="flex min-h-screen flex-col" data-testid="app-shell">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default AppShell;

--- a/next-app/components/Parser/ParserPanel.tsx
+++ b/next-app/components/Parser/ParserPanel.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useParserPlaceholder } from "../../hooks/useParserPlaceholder";
+
+export function ParserPanel() {
+  const { inputSentence, setInputSentence, isParsing, parse, resultSentence, inputHint } =
+    useParserPlaceholder();
+
+  return (
+    <section className="flex min-h-[60vh] flex-col rounded-2xl border bg-white p-4" data-testid="parser-panel">
+      <div className="grid h-full grid-rows-2 gap-4">
+        <div className="flex flex-col">
+          <div className="mb-2 flex gap-2">
+            <div className="w-full">
+              <h2 className="text-base font-semibold">输入</h2>
+              <p className="mt-0.5 text-xs text-gray-500">{inputHint}</p>
+            </div>
+            <button
+              type="button"
+              onClick={parse}
+              disabled={isParsing || !inputSentence}
+              className="rounded-md border px-3 py-2 text-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-100"
+              aria-label="解析句子"
+            >
+              {isParsing ? (
+                <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4A4 4 0 008 12H4z"></path>
+                </svg>
+              ) : (
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </button>
+          </div>
+          <textarea
+            value={inputSentence}
+            onChange={(event) => setInputSentence(event.target.value)}
+            className="flex-1 resize-none rounded-md border px-3 py-2 text-sm"
+            placeholder="例如：小孩在屋子里吃饭。"
+          />
+        </div>
+
+        <div className="flex flex-col">
+          <div className="mb-2">
+            <h2 className="text-base font-semibold">结果</h2>
+            <p className="mt-0.5 text-xs text-gray-500">这里显示根据结构树生成的内容（占位）。</p>
+          </div>
+          <div className="flex-1 overflow-auto rounded-md border bg-gray-50 p-3 text-sm">
+            <p className="text-gray-500">{resultSentence}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default ParserPanel;

--- a/next-app/components/StructureTree/StructureTreePanel.tsx
+++ b/next-app/components/StructureTree/StructureTreePanel.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useStructureTreePlaceholder } from "../../hooks/useStructureTreePlaceholder";
+
+export function StructureTreePanel() {
+  const {
+    entries,
+    toggleStructureRow,
+    addStructureRow,
+    removeStructureRow,
+    sendStructureRow,
+    canSendStructureRow,
+    structureSummary,
+    loadingHint,
+    updateEntryField,
+  } = useStructureTreePlaceholder();
+
+  return (
+    <section className="flex min-h-[60vh] flex-col rounded-2xl border bg-white p-4" data-testid="structure-tree-panel">
+      <div className="mb-3">
+        <h2 className="text-base font-semibold">结构树</h2>
+        <p className="mt-0.5 text-xs text-gray-500">{loadingHint}</p>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-3 overflow-hidden">
+        {entries.length === 0 ? (
+          <div className="flex-1 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500">
+            暂无结构条目，请先解析或点击下方“添加条目”。
+          </div>
+        ) : (
+          <div className="flex-1 overflow-auto pr-1">
+            <div className="space-y-2">
+              {entries.map((entry, index) => (
+                <div key={entry.id} className="rounded-lg border bg-white shadow-sm">
+                  <div className="flex items-center gap-2 px-3 py-2">
+                    <button
+                      type="button"
+                      className="flex h-7 w-7 items-center justify-center rounded border text-gray-500 hover:bg-gray-100"
+                      onClick={() => toggleStructureRow(entry.id)}
+                      aria-label={entry.expanded ? "收起条目" : "展开条目"}
+                    >
+                      {entry.expanded ? (
+                        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M6 9l6 6 6-6" />
+                        </svg>
+                      ) : (
+                        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M9 6l6 6-6 6" />
+                        </svg>
+                      )}
+                    </button>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-gray-800">{structureSummary(entry)}</p>
+                      <p className="text-xs text-gray-500">条目 {index + 1}</p>
+                    </div>
+                    <button
+                      type="button"
+                      className="flex h-8 w-8 items-center justify-center rounded border text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+                      onClick={() => sendStructureRow(entry.id)}
+                      disabled={!canSendStructureRow(entry)}
+                      aria-label={entry.sending ? "发送中" : "发送条目"}
+                    >
+                      <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M5 12h14" />
+                        <path d="M12 5l7 7-7 7" />
+                      </svg>
+                    </button>
+                    {entry.sending && (
+                      <span className="w-12 text-right text-xs font-medium text-blue-600 tabular-nums">
+                        {entry.elapsed}s
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      className="flex h-8 w-8 items-center justify-center rounded border text-red-500 hover:bg-red-50"
+                      onClick={() => removeStructureRow(entry.id)}
+                      aria-label="删除条目"
+                    >
+                      <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M18 6L6 18" />
+                        <path d="M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                  {entry.expanded && (
+                    <div className="space-y-3 border-t bg-gray-50 px-5 py-3">
+                      <div className="grid grid-cols-[52px_1fr] items-center gap-2">
+                        <span className="text-xs font-medium text-gray-500">概述</span>
+                        <input
+                          value={entry.summary}
+                          onChange={(event) => updateEntryField(entry.id, "summary", event.target.value)}
+                          className="w-full rounded-md border px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-200"
+                          placeholder="条目概述"
+                        />
+                      </div>
+                      <div className="grid grid-cols-[52px_1fr] items-start gap-2">
+                        <span className="pt-1 text-xs font-medium text-gray-500">情景</span>
+                        <textarea
+                          value={entry.情景}
+                          onChange={(event) => updateEntryField(entry.id, "情景", event.target.value)}
+                          rows={2}
+                          className="w-full rounded-md border px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-200"
+                          placeholder="描述情景或条件"
+                        />
+                      </div>
+                      <div className="grid grid-cols-[52px_1fr] items-start gap-2">
+                        <span className="pt-1 text-xs font-medium text-gray-500">主语</span>
+                        <textarea
+                          value={entry.主语}
+                          onChange={(event) => updateEntryField(entry.id, "主语", event.target.value)}
+                          rows={2}
+                          className="w-full rounded-md border px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-200"
+                          placeholder="句子的主语"
+                        />
+                      </div>
+                      <div className="grid grid-cols-[52px_1fr] items-start gap-2">
+                        <span className="pt-1 text-xs font-medium text-gray-500">其他</span>
+                        <textarea
+                          value={entry.其他}
+                          onChange={(event) => updateEntryField(entry.id, "其他", event.target.value)}
+                          rows={2}
+                          className="w-full rounded-md border px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-200"
+                          placeholder="其余成分或备注"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        <div>
+          <button
+            type="button"
+            onClick={addStructureRow}
+            className="flex w-full items-center justify-center gap-2 rounded-md border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50"
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 5v14" />
+              <path d="M5 12h14" />
+            </svg>
+            添加条目
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default StructureTreePanel;

--- a/next-app/components/placeholders/PlaceholderButton.tsx
+++ b/next-app/components/placeholders/PlaceholderButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ButtonHTMLAttributes } from "react";
+
+type PlaceholderButtonProps = {
+  label: string;
+  tooltip?: string;
+  onClickPlaceholder?: () => void;
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick">;
+
+export function PlaceholderButton({
+  label,
+  tooltip,
+  onClickPlaceholder,
+  ...buttonProps
+}: PlaceholderButtonProps) {
+  return (
+    <button
+      type="button"
+      className="rounded-md border px-3 py-1.5 text-sm hover:bg-gray-50"
+      title={tooltip}
+      onClick={() => {
+        console.info(`${label} placeholder clicked`);
+        onClickPlaceholder?.();
+      }}
+      {...buttonProps}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default PlaceholderButton;

--- a/next-app/hooks/useDictionarySearch.ts
+++ b/next-app/hooks/useDictionarySearch.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { DictionaryEntry } from "../types/dictionary";
+import { getSampleDictionaryEntries } from "../lib/placeholders/dictionaryClient";
+
+export function useDictionarySearch() {
+  const [searchText, setSearchText] = useState("");
+  const rows = useMemo(() => getSampleDictionaryEntries(), []);
+
+  const filteredRows = useMemo(() => {
+    if (!searchText) {
+      return rows;
+    }
+    const normalized = searchText.trim().toLowerCase();
+    return rows.filter((row) =>
+      [row.source, row.translation, row.description].some((value) =>
+        value.toLowerCase().includes(normalized)
+      )
+    );
+  }, [rows, searchText]);
+
+  return {
+    searchText,
+    setSearchText,
+    rows,
+    filteredRows,
+  } satisfies {
+    searchText: string;
+    setSearchText: (value: string) => void;
+    rows: DictionaryEntry[];
+    filteredRows: DictionaryEntry[];
+  };
+}

--- a/next-app/hooks/useParserPlaceholder.ts
+++ b/next-app/hooks/useParserPlaceholder.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+export function useParserPlaceholder() {
+  const [inputSentence, setInputSentence] = useState("小孩在屋子里吃饭。");
+  const [isParsing, setIsParsing] = useState(false);
+  const [resultSentence, setResultSentence] = useState("这里显示根据结构树生成的内容（占位）。");
+
+  const inputHint = useMemo(() => {
+    if (isParsing) {
+      return "已解析 0 秒（占位）";
+    }
+    return "输入要分解的句子，请勿输入过于复杂（从句套从句）的句子。";
+  }, [isParsing]);
+
+  const parse = async () => {
+    setIsParsing(true);
+    console.info("parseToLevel1Tree placeholder invoked", { inputSentence });
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    setResultSentence(`解析结果占位：${inputSentence}`);
+    setIsParsing(false);
+  };
+
+  return {
+    inputSentence,
+    setInputSentence,
+    isParsing,
+    parse,
+    resultSentence,
+    inputHint,
+  } as const;
+}

--- a/next-app/hooks/useStatusPlaceholders.ts
+++ b/next-app/hooks/useStatusPlaceholders.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ApiStatus, DictionaryStatus } from "../types/status";
+
+export function useDictionaryStatusPlaceholder(): DictionaryStatus {
+  return useMemo(
+    () => ({
+      state: "success",
+      totalEntries: 1234,
+    }),
+    []
+  );
+}
+
+export function useApiStatusPlaceholder(): ApiStatus {
+  return useMemo(
+    () => ({
+      state: "idle",
+      message: "未连接",
+    }),
+    []
+  );
+}

--- a/next-app/hooks/useStructureTreePlaceholder.ts
+++ b/next-app/hooks/useStructureTreePlaceholder.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type { StructureEntry } from "../types/structure";
+
+function createId(prefix: string) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+const INITIAL_ENTRIES: StructureEntry[] = [
+  {
+    id: "entry-1",
+    summary: "条目 1：示例结构",
+    expanded: false,
+    sending: false,
+    elapsed: 0,
+    情景: "示例情景",
+    主语: "示例主语",
+    其他: "示例其他信息",
+  },
+];
+
+export function useStructureTreePlaceholder() {
+  const [entries, setEntries] = useState<StructureEntry[]>(INITIAL_ENTRIES);
+
+  const toggleStructureRow = useCallback((id: string) => {
+    setEntries((current) =>
+      current.map((entry) =>
+        entry.id === id ? { ...entry, expanded: !entry.expanded } : entry
+      )
+    );
+  }, []);
+
+  const addStructureRow = useCallback(() => {
+    setEntries((current) => [
+      ...current,
+      {
+        id: createId("entry"),
+        summary: `条目 ${current.length + 1}：待完善`,
+        expanded: true,
+        sending: false,
+        elapsed: 0,
+        情景: "",
+        主语: "",
+        其他: "",
+      },
+    ]);
+  }, []);
+
+  const removeStructureRow = useCallback((id: string) => {
+    setEntries((current) => current.filter((entry) => entry.id !== id));
+  }, []);
+
+  const sendStructureRow = useCallback((id: string) => {
+    console.info("sendStructureRow placeholder invoked", { id });
+  }, []);
+
+  const canSendStructureRow = useCallback((entry: StructureEntry) => !entry.sending, []);
+
+  const structureSummary = useCallback((entry: StructureEntry) => entry.summary, []);
+
+  const loadingHint = useMemo(() => "点击条目右侧的箭头可单独发送，展开后可编辑详情。", []);
+
+  const updateEntryField = useCallback(
+    (id: string, field: keyof Pick<StructureEntry, "summary" | "情景" | "主语" | "其他">, value: string) => {
+      setEntries((current) =>
+        current.map((entry) =>
+          entry.id === id
+            ? {
+                ...entry,
+                [field]: value,
+              }
+            : entry
+        )
+      );
+    },
+    []
+  );
+
+  return {
+    entries,
+    toggleStructureRow,
+    addStructureRow,
+    removeStructureRow,
+    sendStructureRow,
+    canSendStructureRow,
+    structureSummary,
+    loadingHint,
+    updateEntryField,
+  } as const;
+}

--- a/next-app/lib/placeholders/dictionaryClient.ts
+++ b/next-app/lib/placeholders/dictionaryClient.ts
@@ -1,0 +1,21 @@
+import type { DictionaryEntry } from "../../types/dictionary";
+
+export function getSampleDictionaryEntries(): DictionaryEntry[] {
+  return [
+    {
+      source: "jan",
+      translation: "人",
+      description: "表示人类、人物、有人格的存在。",
+    },
+    {
+      source: "tomo",
+      translation: "屋子",
+      description: "建筑物，尤其是房屋。",
+    },
+    {
+      source: "moku",
+      translation: "吃",
+      description: "动词，表示进食或饮用的行为。",
+    },
+  ];
+}

--- a/next-app/lib/placeholders/highlight.tsx
+++ b/next-app/lib/placeholders/highlight.tsx
@@ -1,0 +1,45 @@
+import { Fragment } from "react";
+
+export function HighlightedText({ text, query }: { text: string; query: string }) {
+  if (!query) {
+    return <>{text}</>;
+  }
+
+  const normalizedText = text.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+
+  const segments: { value: string; highlighted: boolean }[] = [];
+  let index = 0;
+
+  while (index < text.length) {
+    const matchIndex = normalizedText.indexOf(normalizedQuery, index);
+    if (matchIndex === -1) {
+      segments.push({ value: text.slice(index), highlighted: false });
+      break;
+    }
+
+    if (matchIndex > index) {
+      segments.push({ value: text.slice(index, matchIndex), highlighted: false });
+    }
+
+    segments.push({
+      value: text.slice(matchIndex, matchIndex + normalizedQuery.length),
+      highlighted: true,
+    });
+    index = matchIndex + normalizedQuery.length;
+  }
+
+  return (
+    <Fragment>
+      {segments.map((segment, segmentIndex) =>
+        segment.highlighted ? (
+          <mark key={segmentIndex} className="bg-yellow-200 text-gray-900">
+            {segment.value}
+          </mark>
+        ) : (
+          <Fragment key={segmentIndex}>{segment.value}</Fragment>
+        )
+      )}
+    </Fragment>
+  );
+}

--- a/next-app/types/dictionary.ts
+++ b/next-app/types/dictionary.ts
@@ -1,0 +1,5 @@
+export type DictionaryEntry = {
+  source: string;
+  translation: string;
+  description: string;
+};

--- a/next-app/types/status.ts
+++ b/next-app/types/status.ts
@@ -1,0 +1,12 @@
+export type StatusState = "idle" | "loading" | "success" | "error";
+
+export type DictionaryStatus = {
+  state: StatusState;
+  totalEntries?: number;
+  errorMessage?: string;
+};
+
+export type ApiStatus = {
+  state: StatusState;
+  message?: string;
+};

--- a/next-app/types/structure.ts
+++ b/next-app/types/structure.ts
@@ -1,0 +1,10 @@
+export type StructureEntry = {
+  id: string;
+  summary: string;
+  expanded: boolean;
+  sending: boolean;
+  elapsed: number;
+  情景: string;
+  主语: string;
+  其他: string;
+};


### PR DESCRIPTION
## Summary
- create a `next-app` folder with a Next.js-friendly component breakdown of the existing interface
- add reusable hooks, placeholder data utilities, and shared types to back the new components
- scaffold placeholder API routes and document follow-up steps for completing the migration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe95a599ac8328b84588eeecc133b7